### PR TITLE
feat: add --custom-config for custom sdr gain values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,13 +261,15 @@ dependencies = [
 
 [[package]]
 name = "dump1090_rs"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "clap 3.0.10",
  "hex",
  "libdump1090_rs",
  "num-complex",
+ "serde",
  "soapysdr",
+ "toml",
 ]
 
 [[package]]
@@ -654,6 +656,9 @@ name = "serde"
 version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_cbor"
@@ -777,6 +782,15 @@ checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ forward the bytes to applications such as [adsb_deku/radar](https://github.com/r
 
 See [quickstart-guide](https://rsadsb.github.io/quickstart.html) for a quick installation guide.
 
-See [rsadsb-blog](https://rsadsb.github.io/v0.5.0.html) for latest release details.
+See [rsadsb-v0.5.0](https://rsadsb.github.io/v0.5.0.html) for latest major release details.
 
 ## Tested Support
 
 Through the use of the [rust-soapysdr](https://github.com/kevinmehall/rust-soapysdr) project,
 we support [many different](https://github.com/pothosware/SoapySDR/wiki) software defined radio devices.
 If you have tested this project on devices not listed below, let me know!
-(you will need to add gain settings to `src/bin/dump1090.rs`)
+(you will need to add gain settings to [config.toml](dump1090_rs/config.toml) or use `--custom-config`)
 
 | Device | Supported/Tested | Recommend | argument          |
 | ------ | :--------------: | :-------: | ----------------- |
@@ -59,14 +59,15 @@ wcampbell0x2a
 ADS-B Demodulator and Server
 
 USAGE:
-    dump1090 [OPTIONS]
+    dump1090_rs [OPTIONS]
 
 OPTIONS:
-        --driver <DRIVER>    soapysdr driver (sdr device)
-    -h, --help               Print help information
-        --host <HOST>        ip address [default: 127.0.0.1]
-        --port <PORT>        port [default: 30002]
-    -V, --version            Print version information
+        --custom-config <CUSTOM_CONFIG>    filepath for config.toml file overriding or adding sdr gain values
+        --driver <DRIVER>                  soapysdr driver name (sdr device) from default `config.toml` or `--custom-config` [default: rtlsdr]
+    -h, --help                             Print help information
+        --host <HOST>                      ip address [default: 127.0.0.1]
+        --port <PORT>                      port [default: 30002]
+    -V, --version                          Print version information
 ```
 
 ## Performance tricks

--- a/dump1090_rs/Cargo.toml
+++ b/dump1090_rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dump1090_rs"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -11,3 +11,5 @@ num-complex = "0.4"
 soapysdr = "0.3"
 libdump1090_rs = { path = "../", version = "0.5" }
 hex = "0.4"
+toml = "0.5.8"
+serde = { version = "1.0", features = ["derive"] }

--- a/dump1090_rs/config.toml
+++ b/dump1090_rs/config.toml
@@ -1,0 +1,19 @@
+# Default gain values
+
+[[sdrs]]
+driver = "rtlsdr"
+
+[[sdrs.gain]]
+name = "TUNER"
+value = 49.6
+
+[[sdrs]]
+driver = "hackrf"
+
+[[sdrs.gain]]
+name = "LNA"
+value = 40.0
+
+[[sdrs.gain]]
+name = "VGA"
+value = 52.0


### PR DESCRIPTION
The config.toml file is compiled into the binary, but you can now
provide gain values for your own soapysdr supported gains or override the compiled ones.