### PR TITLE
feat: add write/read settings from config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -701,8 +701,7 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 [[package]]
 name = "soapysdr"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "918b0c564f1325489e910b5f2032611f84ec9e7e6324a1d7c991bd3d0e382709"
+source = "git+https://github.com/wcampbell0x2a/rust-soapysdr?branch=add-write-read-settings#64eb939ca0d3c675448da2376dfc990bfc438d84"
 dependencies = [
  "log",
  "num-complex",
@@ -712,8 +711,7 @@ dependencies = [
 [[package]]
 name = "soapysdr-sys"
 version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "587c3e3590bd564ea0ee61a7b4043a3e1111155f03da6b7074b93ba8bce6f8b0"
+source = "git+https://github.com/wcampbell0x2a/rust-soapysdr?branch=add-write-read-settings#64eb939ca0d3c675448da2376dfc990bfc438d84"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bindgen"
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.72"
+version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 
 [[package]]
 name = "cexpr"
@@ -106,9 +106,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clang-sys"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa66045b9cb23c2e9c1520732030608b02ee07e5cfaa5a521ec15ded7fa24c90"
+checksum = "4cc00842eed744b858222c4c9faf7243aafc6d33f92f96935263ef4d8a41ce21"
 dependencies = [
  "glob",
  "libc",
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.0.10"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a30c3bf9ff12dfe5dae53f0a96e0febcd18420d1c0e7fad77796d9d5c4b5375"
+checksum = "5177fac1ab67102d8989464efd043c6ff44191b1557ec1ddd489b4f7e1447e77"
 dependencies = [
  "atty",
  "bitflags",
@@ -146,9 +146,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.0.6"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "517358c28fcef6607bf6f76108e02afad7e82297d132a6b846dcc1fc3efcd153"
+checksum = "01d42c94ce7c2252681b5fed4d3627cc807b13dfc033246bd05d5b252399000e"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.6"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97242a70df9b89a65d0b6df3c4bf5b9ce03c5b7309019777fbde37e7537f8762"
+checksum = "c00d6d2ea26e8b151d99093005cb442fb9a37aeaca582a03ec70946f49ab5ed9"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -229,9 +229,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
+checksum = "b5e5bed1f1c269533fa816a0a5492b3545209a205ca1a54842be180eb63a16a6"
 dependencies = [
  "cfg-if",
  "lazy_static",
@@ -263,7 +263,7 @@ dependencies = [
 name = "dump1090_rs"
 version = "0.5.1"
 dependencies = [
- "clap 3.0.10",
+ "clap 3.1.2",
  "hex",
  "libdump1090_rs",
  "num-complex",
@@ -377,9 +377,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.113"
+version = "0.2.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
+checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
 
 [[package]]
 name = "libdump1090_rs"
@@ -556,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
 ]
@@ -647,15 +647,15 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "semver"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+checksum = "a4a3381e03edd24287172047536f20cabde766e2cd3e65e6b00fb3af51c4f38d"
 
 [[package]]
 name = "serde"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
 dependencies = [
  "serde_derive",
 ]
@@ -672,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.133"
+version = "1.0.136"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
+checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -683,9 +683,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.75"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c059c05b48c5c0067d4b4b2b4f0732dd65feb52daf7e0ea09cd87e7dadc1af79"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
 dependencies = [
  "itoa 1.0.1",
  "ryu",
@@ -700,8 +700,9 @@ checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 
 [[package]]
 name = "soapysdr"
-version = "0.3.1"
-source = "git+https://github.com/wcampbell0x2a/rust-soapysdr?branch=add-write-read-settings#64eb939ca0d3c675448da2376dfc990bfc438d84"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f392e81dcbb6bbe263c9283969cef896cac1e8034f32dd4c48171c65ca653802"
 dependencies = [
  "log",
  "num-complex",
@@ -711,7 +712,8 @@ dependencies = [
 [[package]]
 name = "soapysdr-sys"
 version = "0.7.3"
-source = "git+https://github.com/wcampbell0x2a/rust-soapysdr?branch=add-write-read-settings#64eb939ca0d3c675448da2376dfc990bfc438d84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "587c3e3590bd564ea0ee61a7b4043a3e1111155f03da6b7074b93ba8bce6f8b0"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,6 @@ lto = true
 [workspace]
 members = ["dump1090_rs"]
 default-members = ["dump1090_rs"]
+
+[patch.crates-io]
+soapysdr = { git = 'https://github.com/wcampbell0x2a/rust-soapysdr', branch = "add-write-read-settings" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,15 +7,15 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-byteorder = "1.4"
-lazy_static = "1.4"
-libc = "0.2"
+byteorder = "1.4.0"
+lazy_static = "1.4.0"
+libc = "0.2.0"
 num-complex = "0.4"
 hexlit = "0.5.0"
 
 [dev-dependencies]
-assert_hex = "0.2"
-criterion = "0.3"
+assert_hex = "0.2.0"
+criterion = "0.3.0"
 
 [[bench]]
 name = "demod_benchmark"
@@ -27,6 +27,3 @@ lto = true
 [workspace]
 members = ["dump1090_rs"]
 default-members = ["dump1090_rs"]
-
-[patch.crates-io]
-soapysdr = { git = 'https://github.com/wcampbell0x2a/rust-soapysdr', branch = "add-write-read-settings" }

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,5 @@
 [target.armv7-unknown-linux-gnueabihf]
-image = "rsadsb/ci:0.1.0-armv7-unknown-linux-gnueabihf"
+image = "rsadsb/ci:0.1.1-armv7-unknown-linux-gnueabihf"
 
 [target.x86_64-unknown-linux-gnu]
 image = "rsadsb/ci:0.1.0-x86_64-unknown-linux-gnu"

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,6 +2,6 @@ This is used for cross-compile for ci builds.
 See [hub.docker.com/r/rsadsb/ci](https://hub.docker.com/r/rsadsb/ci).
 
 ```
-docker build -f ./armv7-unknown-linux-gnueabihf.Dockerfile -t rsadsb/ci:0.1.0-armv7-unknown-linux-gnueabihf .
+docker build -f ./armv7-unknown-linux-gnueabihf.Dockerfile -t rsadsb/ci:0.1.1-armv7-unknown-linux-gnueabihf .
 docker build -f ./x86_64-unknown-linux-gnu.Dockerfile -t rsadsb/ci:0.1.0-x86_64-unknown-linux-gnu .
 ```

--- a/docker/armv7-unknown-linux-gnueabihf.Dockerfile
+++ b/docker/armv7-unknown-linux-gnueabihf.Dockerfile
@@ -23,3 +23,5 @@ RUN \
     ldconfig
 
 RUN apt-get install -y libclang-dev
+
+ENV LD_LIBRARY_PATH=/usr/local/lib

--- a/dump1090_rs/Cargo.toml
+++ b/dump1090_rs/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 
 [dependencies]
 clap = {version = "3.0.0", features = ["color", "derive", "wrap_help"]}
-num-complex = "0.4"
-soapysdr = "0.3"
-libdump1090_rs = { path = "../", version = "0.5" }
-hex = "0.4"
+num-complex = "0.4.0"
+soapysdr = "0.3.2"
+libdump1090_rs = { path = "../", version = "0.5.0" }
+hex = "0.4.0"
 toml = "0.5.8"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0.0", features = ["derive"] }

--- a/dump1090_rs/config.toml
+++ b/dump1090_rs/config.toml
@@ -8,10 +8,6 @@ driver = "rtlsdr"
 key = "TUNER"
 value = 49.6
 
-[[sdrs.setting]]
-key = "biastee"
-value = "true"
-
 # HackRF
 [[sdrs]]
 driver = "hackrf"

--- a/dump1090_rs/config.toml
+++ b/dump1090_rs/config.toml
@@ -1,19 +1,25 @@
-# Default gain values
+# Default sdr configs. These are included in the binary.
 
+# rtlsdr
 [[sdrs]]
 driver = "rtlsdr"
 
 [[sdrs.gain]]
-name = "TUNER"
+key = "TUNER"
 value = 49.6
 
+[[sdrs.setting]]
+key = "biastee"
+value = "true"
+
+# HackRF
 [[sdrs]]
 driver = "hackrf"
 
 [[sdrs.gain]]
-name = "LNA"
+key = "LNA"
 value = 40.0
 
 [[sdrs.gain]]
-name = "VGA"
+key = "VGA"
 value = 52.0

--- a/dump1090_rs/src/main.rs
+++ b/dump1090_rs/src/main.rs
@@ -1,3 +1,5 @@
+mod sdrconfig;
+
 // std
 use std::io::prelude::*;
 use std::net::{Ipv4Addr, TcpListener};
@@ -5,34 +7,10 @@ use std::net::{Ipv4Addr, TcpListener};
 // third-party
 use clap::Parser;
 use num_complex::Complex;
-use serde::{Deserialize, Serialize};
 
 // crate
 use libdump1090_rs::utils;
-
-#[derive(Debug, Deserialize, Serialize)]
-struct SdrConfig {
-    pub sdrs: Vec<Sdr>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-struct Sdr {
-    pub driver: String,
-    pub setting: Option<Vec<Arg>>,
-    pub gain: Vec<Gain>,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-struct Arg {
-    pub key: String,
-    pub value: String,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-struct Gain {
-    pub key: String,
-    pub value: f64,
-}
+use sdrconfig::{SdrConfig, DEFAULT_CONFIG};
 
 const CUSTOM_CONFIG_HELP: &str = r#"
 filepath for config.toml file overriding or adding sdr config values for soapysdr
@@ -81,7 +59,7 @@ struct Options {
 
 fn main() {
     // read in default compiled config
-    let mut config: SdrConfig = toml::from_str(include_str!("../config.toml")).unwrap();
+    let mut config: SdrConfig = toml::from_str(DEFAULT_CONFIG).unwrap();
 
     // parse opts
     let options = Options::parse();

--- a/dump1090_rs/src/sdrconfig.rs
+++ b/dump1090_rs/src/sdrconfig.rs
@@ -1,0 +1,38 @@
+use serde::{Deserialize, Serialize};
+
+pub const DEFAULT_CONFIG: &str = include_str!("../config.toml");
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SdrConfig {
+    pub sdrs: Vec<Sdr>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Sdr {
+    pub driver: String,
+    pub setting: Option<Vec<Arg>>,
+    pub gain: Vec<Gain>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Arg {
+    pub key: String,
+    pub value: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Gain {
+    pub key: String,
+    pub value: f64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ensure_inlcude_str() {
+        // ensure that the include_str config compiles to an SdrConfig
+        let _: SdrConfig = toml::from_str(DEFAULT_CONFIG).unwrap();
+    }
+}


### PR DESCRIPTION
Add ability to change settings for an sdr device. This is achieved by
using [[sdr.setting]] in a config.toml file. This uses write_setting and
read_setting provided by soapysdr.

Updated --help text to show string without newlines all over

Patch soapysdr-rs to my own branch until this is published or in
soapysdr-rs master.

Use key/value for all Args.

Closes #16