### PR TITLE
chore: bump msrv, strip release builds, add overflow checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
         toolchain:
           - stable
             # msrv
-          - 1.58.1
+          - 1.59.0
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ harness = false
 [profile.release]
 lto = true
 strip = true
+overflow-checks = true
 
 [workspace]
 members = ["dump1090_rs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "libdump1090_rs"
 version = "0.5.1"
 authors = ["Wayne Campbell <wcampbell1995@gmail","John Stanford <johnwstanford@gmail.com>"]
 edition = "2021"
+rust-version = "1.59.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -23,6 +24,7 @@ harness = false
 
 [profile.release]
 lto = true
+strip = true
 
 [workspace]
 members = ["dump1090_rs"]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you have tested this project on devices not listed below, let me know!
 
 
 ## Usage
-**Minimum Supported Rust Version**: 1.56.1.
+**Minimum Supported Rust Version**: 1.59.0
 
 ## Build
 


### PR DESCRIPTION
Add stripping of dump1090_rs binary netting reduction of size from 2.4M -> 860K.

Bump msrv to supported "strip" option of 1.59.0

Waiting for the `1.59.0` release...