### PR TITLE
Improve perf of `demodulate2400` by 38%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Thanks [@Cherenkov11](https://github.com/Cherenkov11) for the feature suggestion.
 - Add `--custom-config` for providing custom configs for SDRs. See `--help` for examples.
 - Improve performance by 2% by using compiler aided `mul_add` [!21](https://github.com/rsadsb/dump1090_rs/pull/21/files).
+- Improve performance by 38% by limiting slice size [!41](https://github.com/rsadsb/dump1090_rs/pull/41).
 
 ### Breaking
 - Stripped release binaries, requires bump of MSRV to `1.59`. This reduces the size of the generated binary from ~800KB to ~400KB.

--- a/README.md
+++ b/README.md
@@ -93,24 +93,16 @@ boost.
 
 ## Benchmark
 
-Reading from a 512KB iq sample to ADS-B bytes takes ~4.0 ms, but feel free to run benchmarks on your own computer.
+Reading from a 512KB iq sample to ADS-B bytes takes ~3.1 ms, but feel free to run benchmarks on your own computer.
 ```
 > RUSTFLAGS="-C target-cpu=native" cargo bench --workspace
 ```
 
-### Faster hardware: Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz
+### Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz
 ```
-01                      time:   [4.2038 ms 4.2099 ms 4.2169 ms]
-02                      time:   [4.1214 ms 4.1273 ms 4.1335 ms]
-03                      time:   [4.0062 ms 4.0124 ms 4.0191 ms]
-```
-
-
-### Slower hardware: Intel(R) Core(TM) i5-6300U CPU @ 2.40GHz
-```
-01                      time:   [5.7163 ms 5.7744 ms 5.8373 ms]
-02                      time:   [5.5845 ms 5.6405 ms 5.7018 ms]
-03                      time:   [5.4486 ms 5.5052 ms 5.5655 ms]
+01                      time:   [3.1767 ms 3.1790 ms 3.1830 ms]
+02                      time:   [3.1185 ms 3.1195 ms 3.1205 ms]
+03                      time:   [3.0345 ms 3.0352 ms 3.0360 ms]
 ```
 
 # Changes

--- a/src/demod_2400.rs
+++ b/src/demod_2400.rs
@@ -161,7 +161,7 @@ pub fn demodulate2400(mag: &MagnitudeBuffer) -> Result<Vec<[u8; 14]>, &'static s
 
 fn check_preamble(preamble: &[u16]) -> Option<(i32, u32, u32)> {
     // This gets rid of the 3 core::panicking::panic_bounds_check calls,
-    // but doesn't loop to improve performance
+    // but doesn't look to improve performance
     assert!(preamble.len() == 14);
 
     // quick check: we must have a rising edge 0->1 and a falling edge 12->13

--- a/src/demod_2400.rs
+++ b/src/demod_2400.rs
@@ -88,7 +88,7 @@ pub fn demodulate2400(mag: &MagnitudeBuffer) -> Result<Vec<[u8; 14]>, &'static s
             continue 'jloop;
         }
 
-        if let Some((high, base_signal, base_noise)) = check_preamble(&data[j..j+14]) {
+        if let Some((high, base_signal, base_noise)) = check_preamble(&data[j..j + 14]) {
             // Check for enough signal
             if base_signal * 2 < 3 * base_noise {
                 // about 3.5dB SNR
@@ -127,7 +127,7 @@ pub fn demodulate2400(mag: &MagnitudeBuffer) -> Result<Vec<[u8; 14]>, &'static s
                     // for each phase-bit
                     for i in 0..8 {
                         // find if phase distance denotes a high bit
-                        if phase.calculate_bit(&slice_this_byte[index..index+4]) > 0 {
+                        if phase.calculate_bit(&slice_this_byte[index..index + 4]) > 0 {
                             the_byte |= 1 << (7 - i);
                         }
                         // increment to next phase, increase index

--- a/src/demod_2400.rs
+++ b/src/demod_2400.rs
@@ -127,7 +127,7 @@ pub fn demodulate2400(mag: &MagnitudeBuffer) -> Result<Vec<[u8; 14]>, &'static s
                     // for each phase-bit
                     for i in 0..8 {
                         // find if phase distance denotes a high bit
-                        if phase.calculate_bit(&slice_this_byte[index..]) > 0 {
+                        if phase.calculate_bit(&slice_this_byte[index..index+4]) > 0 {
                             the_byte |= 1 << (7 - i);
                         }
                         // increment to next phase, increase index


### PR DESCRIPTION
CPU's love him, with these 3 commits.

This mostly just make the slices used by `calculate_bit` and `check_preamble` limited by the biggest `len` needed by the function instead of boundless.