### PR TITLE
WIP: Update docker image / Add aarm64-unknown-linux-gnu

### DIFF
--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -20,11 +20,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - uses: actions-rs/cargo@v1
         with:
           use-cross: true

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -21,11 +21,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: build
-          args: --workspace --locked --release --target ${{ matrix.targets }}
+      - run: cargo install cross
+      - run: cross build --workspace --locked --release --target ${{ matrix.targets }}
 
       - name: archive
         run: |

--- a/.github/workflows/binaries.yml
+++ b/.github/workflows/binaries.yml
@@ -16,6 +16,7 @@ jobs:
         targets:
           - x86_64-unknown-linux-gnu
           - armv7-unknown-linux-gnueabihf
+          - aarch64-unknown-linux-gnu
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,17 +30,9 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           target: ${{ matrix.targets }}
           components: rustfmt, clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: build
-          args: --locked --workspace --target ${{ matrix.targets }}
-
-      - uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: test
-          args: --locked --workspace --target ${{ matrix.targets }}
+      - run: cargo install cross
+      - run: cross build --locked --workspace --target ${{ matrix.targets }}
+      - run: cross test --locked --workspace --target ${{ matrix.targets }}
 
   # fmt and clippy on nightly builds
   fmt-clippy-nightly:
@@ -52,14 +44,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
+          target: x86_64-unknown-linux-gnu
           components: rustfmt, clippy
+      # fmt
+      - run: cargo fmt --all -- --check
 
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --workspace -- -D warnings --target
+      # clippy within cross
+      - run: cargo install cross
+      - run: cross clippy --workspace --target x86_64-unknown-linux-gnu -- -D warnings

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,12 +25,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.toolchain }}
           target: ${{ matrix.targets }}
-          override: true
+          components: rustfmt, clippy
       - uses: actions-rs/cargo@v1
         with:
           use-cross: true
@@ -50,11 +49,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: nightly
-          override: true
           components: rustfmt, clippy
 
       - uses: actions-rs/cargo@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
         targets:
           - x86_64-unknown-linux-gnu
           - armv7-unknown-linux-gnueabihf
+          - aarch64-unknown-linux-gnu
         toolchain:
           - stable
             # msrv

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,10 +46,6 @@ jobs:
   # fmt and clippy on nightly builds
   fmt-clippy-nightly:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        targets:
-          - x86_64-unknown-linux-gnu
 
     steps:
       - uses: actions/checkout@v3
@@ -58,7 +54,6 @@ jobs:
         with:
           profile: minimal
           toolchain: nightly
-          target: ${{ matrix.targets }}
           override: true
           components: rustfmt, clippy
 
@@ -69,6 +64,5 @@ jobs:
 
       - uses: actions-rs/cargo@v1
         with:
-          use-cross: true
           command: clippy
-          args: --workspace -- -D warnings --target ${{ matrix.targets }}
+          args: --workspace -- -D warnings --target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Features
-- Released docker image: `v0.1.1:armv7-unknown-linux-gnueabihf`.
-  Fixes error when running `cargo test` including the shared library `soapysdr`.
+  Fixes error when running `cargo test` including the shared library `soapysdr`
 - Bump `soapysdr-rs` to `v0.3.2`, enabling the use of read/write settings. For example, enabling bias-t on the rtlsdr is now allowed!
   [#16](https://github.com/rsadsb/dump1090_rs/issues/16) [!17](https://github.com/rsadsb/dump1090_rs/pull/17).
-  Thanks [@Cherenkov11](https://github.com/Cherenkov11) for the feature suggestion.
-- Add `--custom-config` for providing custom configs for SDRs. See `--help` for examples.
-- Improve performance by 2% by using compiler aided `mul_add` [!21](https://github.com/rsadsb/dump1090_rs/pull/21/files).
-- Improve performance by 38% by limiting slice size [!41](https://github.com/rsadsb/dump1090_rs/pull/41).
+  Thanks [@Cherenkov11](https://github.com/Cherenkov11) for the feature suggestion
+- Add `--custom-config` for providing custom configs for SDRs. See `--help` for examples
+- Improve performance by 2% by using compiler aided `mul_add` [!21](https://github.com/rsadsb/dump1090_rs/pull/21/files)
+- Improve performance by 38% by limiting slice size [!41](https://github.com/rsadsb/dump1090_rs/pull/41)
+- Add support for `aarm64-unknown-linux-gnu`, for Raspberry Pi 64 bit
+- Updated other docker images to `0.2.0`: [docker hub](https://hub.docker.com/repository/docker/rsadsb/ci/tags?page=1&ordering=last_updated&name=0.2.0)
 
 ### Breaking
 - Stripped release binaries, requires bump of MSRV to `1.59`. This reduces the size of the generated binary from ~800KB to ~400KB.

--- a/Cross.toml
+++ b/Cross.toml
@@ -3,3 +3,6 @@ image = "rsadsb/ci:0.2.0-armv7-unknown-linux-gnueabihf"
 
 [target.x86_64-unknown-linux-gnu]
 image = "rsadsb/ci:0.2.0-x86_64-unknown-linux-gnu"
+
+[target.aarch64-unknown-linux-gnu]
+image = "rsadsb/ci:0.2.0-aarch64-unknown-linux-gnu"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,5 @@
 [target.armv7-unknown-linux-gnueabihf]
-image = "rsadsb/ci:0.1.1-armv7-unknown-linux-gnueabihf"
+image = "rsadsb/ci:0.2.0-armv7-unknown-linux-gnueabihf"
 
 [target.x86_64-unknown-linux-gnu]
-image = "rsadsb/ci:0.1.0-x86_64-unknown-linux-gnu"
+image = "rsadsb/ci:0.2.0-x86_64-unknown-linux-gnu"

--- a/README.md
+++ b/README.md
@@ -40,14 +40,20 @@ Using `debug` builds will result in SDR overflows, always using `--release` for 
 
 ### Cross Compile
 Use [hub.docker.com/r/rsadsb](https://hub.docker.com/r/rsadsb/ci/tags) for cross compiling to the following archs.
-These images already have `soapysdr` installed.
+These images already have `soapysdr` installed with the correct cross compilers.
+This uses [cross-rs](https://github.com/cross-rs/cross).
 ```
 > cargo install cross
 > cross build --workspace --target x86_64-unknown-linux-gnu --relese
+
+# Used for example in Raspberry Pi (raspios) 32 bit
 > cross build --workspace --target armv7-unknown-linux-gnueabihf --release
+
+# Used for example in Raspberry Pi (raspios) 64 bit
+> cross build --workspace --target aarm64-unknown-linux-gnu --release
 ```
 
-### Release Builds
+### Release Builds from CI
 Check the [latest release](https://github.com/rsadsb/dump1090_rs/releases) for binaries built from the CI.
 
 ## Run

--- a/README.md
+++ b/README.md
@@ -99,16 +99,25 @@ boost.
 
 ## Benchmark
 
-Reading from a 512KB iq sample to ADS-B bytes takes ~3.1 ms, but feel free to run benchmarks on your own computer.
+Reading from a 512KB iq sample to ADS-B bytes takes ~3.0 ms, but feel free to run benchmarks on your own computer.
 ```
 > RUSTFLAGS="-C target-cpu=native" cargo bench --workspace
 ```
 
-### Intel(R) Core(TM) i7-7700K CPU @ 4.20GHz
+### Intel i7-7700K CPU @ 4.20GHz
+
+#### stable (`rustc 1.62.0 (a8314ef7d 2022-06-27)`)
 ```
-01                      time:   [3.1767 ms 3.1790 ms 3.1830 ms]
-02                      time:   [3.1185 ms 3.1195 ms 3.1205 ms]
-03                      time:   [3.0345 ms 3.0352 ms 3.0360 ms]
+01                      time:   [3.0255 ms 3.0315 ms 3.0391 ms]
+02                      time:   [2.9595 ms 2.9647 ms 2.9710 ms]
+03                      time:   [2.8904 ms 2.8931 ms 2.8960 ms]
+```
+
+#### nightly (`rustc 1.64.0-nightly (87588a2af 2022-07-13)`)
+```
+01                      time:   [3.0763 ms 3.0919 ms 3.1202 ms]
+02                      time:   [3.0075 ms 3.0113 ms 3.0157 ms]
+03                      time:   [2.9437 ms 2.9465 ms 2.9495 ms]
 ```
 
 # Changes

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,7 +2,7 @@ This is used for cross-compile for ci builds.
 See [hub.docker.com/r/rsadsb/ci](https://hub.docker.com/r/rsadsb/ci).
 
 ```
-docker build -f ./aarch64-unknown-linux-gnu.Dockerfile -t rsadsb/ci:0.2.0-armv7-unknown-linux-gnueabihf .
+docker build -f ./aarch64-unknown-linux-gnu.Dockerfile -t rsadsb/ci:0.2.0-aarm64-unknown-linux-gnu .
 docker build -f ./armv7-unknown-linux-gnueabihf.Dockerfile -t rsadsb/ci:0.2.0-armv7-unknown-linux-gnueabihf .
 docker build -f ./x86_64-unknown-linux-gnu.Dockerfile -t rsadsb/ci:0.2.0-x86_64-unknown-linux-gnu .
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,6 +2,7 @@ This is used for cross-compile for ci builds.
 See [hub.docker.com/r/rsadsb/ci](https://hub.docker.com/r/rsadsb/ci).
 
 ```
+docker build -f ./aarch64-unknown-linux-gnu.Dockerfile -t rsadsb/ci:0.2.0-armv7-unknown-linux-gnueabihf .
 docker build -f ./armv7-unknown-linux-gnueabihf.Dockerfile -t rsadsb/ci:0.2.0-armv7-unknown-linux-gnueabihf .
 docker build -f ./x86_64-unknown-linux-gnu.Dockerfile -t rsadsb/ci:0.2.0-x86_64-unknown-linux-gnu .
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,6 +2,6 @@ This is used for cross-compile for ci builds.
 See [hub.docker.com/r/rsadsb/ci](https://hub.docker.com/r/rsadsb/ci).
 
 ```
-docker build -f ./armv7-unknown-linux-gnueabihf.Dockerfile -t rsadsb/ci:0.1.1-armv7-unknown-linux-gnueabihf .
-docker build -f ./x86_64-unknown-linux-gnu.Dockerfile -t rsadsb/ci:0.1.0-x86_64-unknown-linux-gnu .
+docker build -f ./armv7-unknown-linux-gnueabihf.Dockerfile -t rsadsb/ci:0.2.0-armv7-unknown-linux-gnueabihf .
+docker build -f ./x86_64-unknown-linux-gnu.Dockerfile -t rsadsb/ci:0.2.0-x86_64-unknown-linux-gnu .
 ```

--- a/docker/aarch64-unknown-linux-gnu.Dockerfile
+++ b/docker/aarch64-unknown-linux-gnu.Dockerfile
@@ -1,0 +1,27 @@
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.2
+
+RUN apt-get update -y && apt-get install -y cmake git llvm-dev libclang-common-8-dev pkg-config clang-8
+
+RUN \
+    git clone https://github.com/pothosware/SoapySDR.git &&\
+    cd SoapySDR &&\
+    git checkout soapy-sdr-0.8.1 &&\
+    mkdir build &&\
+    cd build &&\
+    cmake \
+        -D CMAKE_C_COMPILER=/usr/bin/aarch64-linux-gnu-gcc \
+        -D CMAKE_CXX_COMPILER=/usr/bin/aarch64-linux-gnu-g++ \
+        -D CMAKE_AR=/usr/bin/aarch64-linux-gnu-ar \
+        -D CMAKE_C_COMPILER_AR=/usr/bin/aarch64-linux-gnu-gcc-ar \
+        -D CMAKE_C_COMPILER_RANLIB=/usr/bin/aarch64-linux-gnu-gcc-ranlib \
+        -D CMAKE_LINKER=/usr/bin/aarch64-linux-gnu-ld \
+        -D CMAKE_NM=/usr/bin/aarch64-linux-gnu-nm \
+        -D CMAKE_OBJCOPY=/usr/bin/aarch64-linux-gnu-objcopy \
+        -D CMAKE_OBJDUMP=/usr/bin/aarch64-linux-gnu-objdump \
+        -D CMAKE_RANLIB=/usr/bin/aarch64-linux-gnu-ranlib \
+        -D CMAKE_STRIP=/usr/bin/aarch64-linux-gnu-strip .. &&\
+    make -j4 &&\
+    make install &&\
+    ldconfig
+
+ENV LD_LIBRARY_PATH=/usr/local/lib

--- a/docker/aarch64-unknown-linux-gnu.Dockerfile
+++ b/docker/aarch64-unknown-linux-gnu.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.2
+FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.4
 
 RUN apt-get update -y && apt-get install -y cmake git llvm-dev libclang-common-8-dev pkg-config clang-8
 

--- a/docker/armv7-unknown-linux-gnueabihf.Dockerfile
+++ b/docker/armv7-unknown-linux-gnueabihf.Dockerfile
@@ -1,5 +1,7 @@
 FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:0.2.4
 
+RUN apt-get update -y && apt-get install -y cmake git llvm-dev libclang-common-8-dev pkg-config clang-8
+
 RUN \
     git clone https://github.com/pothosware/SoapySDR.git &&\
     cd SoapySDR &&\
@@ -21,7 +23,5 @@ RUN \
     make -j4 &&\
     make install &&\
     ldconfig
-
-RUN apt-get update -y && apt-get install -y libclang-dev
 
 ENV LD_LIBRARY_PATH=/usr/local/lib

--- a/docker/armv7-unknown-linux-gnueabihf.Dockerfile
+++ b/docker/armv7-unknown-linux-gnueabihf.Dockerfile
@@ -1,4 +1,4 @@
-FROM rustembedded/cross:armv7-unknown-linux-gnueabihf-0.2.1
+FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:0.2.2
 
 RUN \
     git clone https://github.com/pothosware/SoapySDR.git &&\
@@ -22,6 +22,6 @@ RUN \
     make install &&\
     ldconfig
 
-RUN apt-get install -y libclang-dev
+RUN apt-get update -y && apt-get install -y libclang-dev
 
 ENV LD_LIBRARY_PATH=/usr/local/lib

--- a/docker/armv7-unknown-linux-gnueabihf.Dockerfile
+++ b/docker/armv7-unknown-linux-gnueabihf.Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:0.2.2
+FROM ghcr.io/cross-rs/armv7-unknown-linux-gnueabihf:0.2.4
 
 RUN \
     git clone https://github.com/pothosware/SoapySDR.git &&\

--- a/docker/x86_64-unknown-linux-gnu.Dockerfile
+++ b/docker/x86_64-unknown-linux-gnu.Dockerfile
@@ -1,6 +1,6 @@
-#ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.4 is ancient, so use rust images (ubuntu 16.04/clang 3.8)
-FROM rust:1.59-slim-buster
+FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main
 
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y && apt-get install -y cmake git llvm-dev libclang-dev clang pkg-config
 
 RUN \

--- a/docker/x86_64-unknown-linux-gnu.Dockerfile
+++ b/docker/x86_64-unknown-linux-gnu.Dockerfile
@@ -1,5 +1,5 @@
+#ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.4 is ancient, so use rust images (ubuntu 16.04/clang 3.8)
 FROM rust:1.59-slim-buster
-FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.4
 
 RUN apt-get update -y && apt-get install -y cmake git llvm-dev libclang-dev clang pkg-config
 
@@ -12,4 +12,5 @@ RUN \
     cmake -D CMAKE_INSTALL_PREFIX=/ .. &&\
     make -j4 &&\
     make install
+
 ENV LD_LIBRARY_PATH=/usr/local/lib

--- a/docker/x86_64-unknown-linux-gnu.Dockerfile
+++ b/docker/x86_64-unknown-linux-gnu.Dockerfile
@@ -1,4 +1,5 @@
 FROM rust:1.59-slim-buster
+FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.4
 
 RUN apt-get update -y && apt-get install -y cmake git llvm-dev libclang-dev clang pkg-config
 

--- a/docker/x86_64-unknown-linux-gnu.Dockerfile
+++ b/docker/x86_64-unknown-linux-gnu.Dockerfile
@@ -1,4 +1,6 @@
-FROM rustembedded/cross:x86_64-unknown-linux-gnu
+FROM rust:1.59-slim-buster
+
+RUN apt-get update -y && apt-get install -y cmake git llvm-dev libclang-dev clang pkg-config
 
 RUN \
     git clone https://github.com/pothosware/SoapySDR.git &&\
@@ -9,12 +11,4 @@ RUN \
     cmake -D CMAKE_INSTALL_PREFIX=/ .. &&\
     make -j4 &&\
     make install
-
-RUN yum update -y && \
-    yum install centos-release-scl -y && \
-    yum install llvm-toolset-7 -y
-
-ENV LIBCLANG_PATH=/opt/rh/llvm-toolset-7/root/usr/lib64/ \
-    LIBCLANG_STATIC_PATH=/opt/rh/llvm-toolset-7/root/usr/lib64/ \
-    CLANG_PATH=/opt/rh/llvm-toolset-7/root/usr/bin/clang
-
+ENV LD_LIBRARY_PATH=/usr/local/lib


### PR DESCRIPTION
* Add support for building `aarm64-unknown-linux-gnu` for supporting the Raspberry Pi 64-bit
* Add new CI images that are pushed to docker hub
* update cargo/cross base images -> 0.2.2